### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,8 +1,32 @@
 
+#!/usr/bin/env bash
+
+# Re-exec with bash when invoked as "sh build.sh".
+if [ -z "${BASH_VERSION:-}" ]; then
+  exec bash "$0" "$@"
+fi
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+if [ ! -f dist/ABL.efi ]; then
+  echo "dist/ABL.efi not found. Run ./patch.sh first (or use ./auto.sh)." >&2
+  exit 1
+fi
+
 xxd -i dist/ABL.efi > edk2/QcomModulePkg/Include/Library/ABL.h
-cp -r ./Conf ./edk2/
+
+if [ -d ./Conf ]; then
+  rm -rf ./edk2/Conf
+  cp -r ./Conf ./edk2/
+else
+  mkdir -p ./edk2/Conf
+fi
+
 cd edk2
-source edksetup.sh
+source edksetup.sh --reconfig
 make BOARD_BOOTLOADER_PRODUCT_NAME=canoe TARGET_ARCHITECTURE=AARCH64 TARGET=RELEASE \
   CLANG_BIN=/usr/bin/ CLANG_PREFIX=aarch64-linux-gnu- VERIFIED_BOOT_ENABLED=1 \
   VERIFIED_BOOT_LE=0 AB_RETRYCOUNT_DISABLE=0 TARGET_BOARD_TYPE_AUTO=0 \
@@ -10,6 +34,8 @@ make BOARD_BOOTLOADER_PRODUCT_NAME=canoe TARGET_ARCHITECTURE=AARCH64 TARGET=RELE
   REMOVE_CARVEOUT_REGION=1 QSPA_BOOTCONFIG_ENABLE=1 USER_BUILD_VARIANT=0 \
   PREBUILT_HOST_TOOLS="BUILD_CC=clang BUILD_CXX=clang++ LDPATH=-fuse-ld=lld BUILD_AR=llvm-ar"
 cd ../
-cp edk2/Build/RELEASE_CLANG35/AARCH64/LinuxLoader.efi ./dist/TEST_superfastboot.efi
-cat ./dist/patch_log.txt
+cp edk2/Build/RELEASE_CLANG35/AARCH64/LinuxLoader.efi ./dist/ABL_with_superfastboot.efi
+if [ -f ./dist/patch_log.txt ]; then
+  cat ./dist/patch_log.txt
+fi
 ls -l ./dist


### PR DESCRIPTION
Resolves #2 
This change hardens the build flow for ABL packaging and EDK2 compilation by making execution deterministic and repeatable. The script now enforces Bash (the main problem), resolves from the repo root, validates required artifacts, recreates Conf cleanly, and runs edksetup with reconfiguration to prevent stale environment issues. It also adds strict error handling and guards optional log output, reducing flaky or context-dependent build failures.