### PR TITLE
fix: adapt WebUI to APatch

### DIFF
--- a/magisk_module/webroot/app.js
+++ b/magisk_module/webroot/app.js
@@ -45,9 +45,20 @@ function toast(message) {
 
 function moduleInfo() {
   const bridge = getKsuBridge();
-  if (!bridge?.moduleInfo) throw new Error("当前页面不在 KernelSU WebUI 环境中");
-  const raw = bridge.moduleInfo();
-  return typeof raw === "string" ? JSON.parse(raw) : raw;
+  if (!bridge) throw new Error("当前页面不在 KernelSU / APatch WebUI 环境中");
+
+  if (bridge.moduleInfo) {
+    const raw = bridge.moduleInfo();
+    return typeof raw === "string" ? JSON.parse(raw) : raw;
+  }
+
+  const found = extractStdout(
+    bridge.exec(
+      'for d in /data/adb/modules/*/; do [ -f "${d}bin/bl_flasher.sh" ] && printf "%s" "${d%/}" && break; done'
+    )
+  ).trim();
+  if (!found) throw new Error("APatch: 无法定位模块目录，请确认模块已启用");
+  return { moduleDir: found };
 }
 
 function extractStdout(raw) {

--- a/magisk_module/webroot/index.html
+++ b/magisk_module/webroot/index.html
@@ -13,7 +13,7 @@
           <p class="eyebrow">KernelSU Module WebUI</p>
           <h1>BL Flasher</h1>
           <p class="hero-copy">
-            自动识别当前活动槽位，将ABL镜像刷写到另一个槽位(如果另一个槽位的ABL存在GBL漏洞，则不将当前槽位ABL镜像刷写到另一个槽位)，并按需求自动修补另一个槽位的ABL到efisp
+            自动识别当前活动槽位，将ABL镜像刷写到另一个槽位(如果另一个槽位的ABL存在GBL漏洞，则刷写另一个槽位的行为不生效)，并按需求自动修补另一个槽位的ABL到efisp
           </p>
         </div>
         <div class="hero-meta">

--- a/magisk_module/webroot/index.html
+++ b/magisk_module/webroot/index.html
@@ -13,7 +13,7 @@
           <p class="eyebrow">KernelSU Module WebUI</p>
           <h1>BL Flasher</h1>
           <p class="hero-copy">
-            自动识别当前活动槽位，如果新版本存在GBL漏洞，则跳过BL刷写，同时将BL相关镜像刷写到另一个槽位，并按需求自动修补新版ABL到efisp
+            自动识别当前活动槽位，将ABL镜像刷写到另一个槽位(如果另一个槽位的ABL存在GBL漏洞，则不将当前槽位ABL镜像刷写到另一个槽位)，并按需求自动修补另一个槽位的ABL到efisp
           </p>
         </div>
         <div class="hero-meta">


### PR DESCRIPTION
APatch 的 WebViewInterface 未实现 bridge.moduleInfo，导致 init() 在
APatch 环境下直接抛出异常，WebUI 完全无法初始化。

在 moduleInfo() 内增加兼容分支：检测到 bridge.moduleInfo 不存在时，
通过 bridge.exec扫描 /data/adb/modules/ 找到模块目录，返回与原接口相同
结构的对象。