### PR TITLE
fix Multiplication result converted to larger type problem

### DIFF
--- a/edk2/MdeModulePkg/Universal/Variable/RuntimeDxe/Reclaim.c
+++ b/edk2/MdeModulePkg/Universal/Variable/RuntimeDxe/Reclaim.c
@@ -76,7 +76,7 @@ GetLbaAndOffsetByAddress (
         // Found the (Lba, Offset).
         //
         *Lba    = LbaIndex - 1;
-        *Offset = (UINTN) (Address - (FvbBaseAddress + FvbMapEntry->Length * (LbaIndex - 1)));
+        *Offset = (UINTN) (Address - (FvbBaseAddress + (EFI_PHYSICAL_ADDRESS)FvbMapEntry->Length * (LbaIndex - 1)));
         return EFI_SUCCESS;
      }
     }


### PR DESCRIPTION
乘法结果在转换为unsigned long long之前可能溢出‘unsigned int’变量本身