### PR TITLE
增加ColorOS 16.0.8.x防熔断机制

### DIFF
--- a/submodules/arb_guard_kpm/README.md
+++ b/submodules/arb_guard_kpm/README.md
@@ -1,0 +1,44 @@
+# arb_guard KPM
+
+KernelSU Kernel Patch Module that suppresses the ColorOS ARB (Anti-Rollback) eFuse write.
+
+## Background
+
+ColorOS 16.0.8+ ships `qcom-dload-mode.ko` (vendor_boot ramdisk) which exposes
+`/sys/kernel/dload/update_arb`. During boot, the Boot HAL writes `1` to this node,
+causing `qcom_scm_update_rollback_version()` (from `qcom-scm.ko`) to issue an SMC
+call (svc=0x01, cmd=0x1E) into TrustZone, which irreversibly burns QFPROM ARB eFuses.
+
+## This KPM
+
+Hooks `qcom_scm_update_rollback_version` at runtime via KPatch-Next and returns 0
+immediately, preventing the SMC call and eFuse burn.
+
+## Build Requirements
+
+- OKI kernel built with `kpm_enable=true` (KPatch-Next applied to `Image`)
+- KPatch-Next headers (`kpm_utils.h`) in include path
+- `aarch64-linux-android` clang toolchain
+
+```sh
+# Build using the OKI workflow's clang toolchain
+clang --target=aarch64-linux-android \
+  -I<kpatch_next_headers> \
+  -shared -fPIC -o arb_guard.kpm arb_guard.c
+```
+
+## Deployment
+
+Place `arb_guard.kpm` in a KernelSU module:
+```
+/data/adb/modules/<module>/
+    module.prop
+    post-fs-data.sh   ← run: ksud kpm load /path/to/arb_guard.kpm
+```
+
+## Layered Defense
+
+This KPM is the second layer. The first layer is `post-fs-data.sh` in the
+`fake_bl_efisp` Magisk module, which `chmod 000`s the sysfs node before the
+Boot HAL starts. The KPM is required if the sysfs approach is bypassed (e.g.,
+if the HAL runs as a trusted process that ignores DAC).

--- a/submodules/arb_guard_kpm/arb_guard.c
+++ b/submodules/arb_guard_kpm/arb_guard.c
@@ -1,0 +1,59 @@
+// arb_guard.c — KernelSU/KPatch-Next KPM
+//
+// Intercepts qcom_scm_update_rollback_version() exported by qcom-scm.ko
+// before TrustZone burns the ARB eFuse (SMC svc=0x01 cmd=0x1E).
+//
+// Load order: qcom-scm.ko is loaded during first-stage init; this KPM is
+// loaded by KernelSU after /data is mounted. The hook targets the already-
+// loaded module symbol via KPatch-Next hook_func().
+//
+// Build: use the OKI kernel's KPatch-Next kptools to patch the Image, then
+// load this KPM via a KernelSU module (place the .kpm in /data/adb/kpm/).
+
+#include <kpm_utils.h>
+
+KPM_NAME("arb-guard");
+KPM_VERSION("1.0.0");
+KPM_DESCRIPTION("Suppresses ARB eFuse writes via qcom_scm_update_rollback_version hook");
+KPM_AUTHOR("gbl_root_canoe");
+KPM_LICENSE("GPL v2");
+
+static int (*orig_qcom_scm_update_rollback_version)(void) = NULL;
+
+// Replacement: log and return success without calling TrustZone.
+static int arb_guard_hook(void)
+{
+    pr_warn_once("arb_guard: qcom_scm_update_rollback_version suppressed — ARB eFuse protected\n");
+    return 0;
+}
+
+static long arb_guard_init(const char *args, const char *event, void *reserved)
+{
+    int rc = hook_func("qcom_scm_update_rollback_version",
+                       (void *)arb_guard_hook,
+                       (void **)&orig_qcom_scm_update_rollback_version);
+    if (rc) {
+        pr_err("arb_guard: hook failed (%d) — symbol not found or KPM not supported\n", rc);
+        return rc;
+    }
+    pr_info("arb_guard: hook installed on qcom_scm_update_rollback_version\n");
+    return 0;
+}
+
+static long arb_guard_control(const char *args, const char *event, void *reserved)
+{
+    return 0;
+}
+
+static long arb_guard_exit(void *reserved)
+{
+    unhook_func("qcom_scm_update_rollback_version",
+                (void *)arb_guard_hook,
+                (void **)&orig_qcom_scm_update_rollback_version);
+    pr_info("arb_guard: hook removed\n");
+    return 0;
+}
+
+KPM_INIT(arb_guard_init);
+KPM_CONTROL(arb_guard_control);
+KPM_EXIT(arb_guard_exit);

--- a/submodules/arb_guard_kpm/oki_workflow.patch
+++ b/submodules/arb_guard_kpm/oki_workflow.patch
@@ -1,0 +1,108 @@
+diff --git a/.github/workflows/fastbuild_6.12.23.yml b/.github/workflows/fastbuild_6.12.23.yml
+index 09919cf..316c2a9 100644
+--- a/.github/workflows/fastbuild_6.12.23.yml
++++ b/.github/workflows/fastbuild_6.12.23.yml
+@@ -32,6 +32,11 @@ on:
+         required: true
+         type: boolean
+         default: 'false'
++      arb_guard_enable:
++        description: '是否启用ARB eFuse防熔断KPM(在开启kpm的前提下，拦截qcom_scm_update_rollback_version，阻止ColorOS 16.0.8+每次开机自动熔断ARB eFuse；需同时开启kpm)'
++        required: true
++        type: boolean
++        default: 'true'
+       lz4_enable:
+         description: '是否安装 lz4 1.10.0+zstd 1.5.7 补丁'
+         required: true
+@@ -703,7 +708,74 @@ jobs:
+           ./kptools-linux -p -i ./Image -k ./kpimg-linux -o ./oImage
+           rm -f Image
+           mv oImage Image
+-          
++
++      - name: 构建ARB Guard KPM
++        if: inputs.kpm_enable && inputs.arb_guard_enable
++        run: |
++          echo "正在构建ARB eFuse防熔断KPM..."
++          WORKDIR="$(pwd)"
++          CLANG="$WORKDIR/kernel_workspace/clang19/bin/clang"
++
++          # 下载KPatch-Next KPM头文件
++          mkdir -p arb_kpm_build
++          wget -q https://github.com/KernelSU-Next/KPatch-Next/releases/latest/download/kpatch-next-headers.zip \
++            -O arb_kpm_build/kpn_headers.zip \
++            && unzip -q arb_kpm_build/kpn_headers.zip -d arb_kpm_build/headers \
++            || { echo "kpn headers not available as zip, fetching individually..."; \
++                 wget -q https://raw.githubusercontent.com/KernelSU-Next/KernelPatch/next/kernel/patch/include/kpm_utils.h \
++                   -O arb_kpm_build/kpm_utils.h 2>/dev/null \
++                 || wget -q https://raw.githubusercontent.com/bmax121/KernelPatch/main/kernel/patch/include/kpm_utils.h \
++                   -O arb_kpm_build/kpm_utils.h; }
++
++          # 写入arb_guard KPM源码
++          cat > arb_kpm_build/arb_guard.c << 'ARBC'
++          // arb_guard.c: suppress qcom_scm_update_rollback_version() ARB eFuse burn
++          #include <kpm_utils.h>
++          KPM_NAME("arb-guard");
++          KPM_VERSION("1.0.0");
++          KPM_DESCRIPTION("Suppress ARB eFuse burn via qcom_scm_update_rollback_version hook");
++          KPM_AUTHOR("gbl_root_canoe");
++          KPM_LICENSE("GPL v2");
++          static int (*orig_fn)(void) = NULL;
++          static int arb_guard_hook(void) {
++              pr_warn_once("arb_guard: qcom_scm_update_rollback_version suppressed\n");
++              return 0;
++          }
++          static long arb_init(const char *a, const char *e, void *r) {
++              int rc = hook_func("qcom_scm_update_rollback_version",
++                                 (void *)arb_guard_hook, (void **)&orig_fn);
++              if (rc) pr_err("arb_guard: hook failed %d\n", rc);
++              else    pr_info("arb_guard: hook installed\n");
++              return rc;
++          }
++          static long arb_ctrl(const char *a, const char *e, void *r) { return 0; }
++          static long arb_exit(void *r) {
++              unhook_func("qcom_scm_update_rollback_version",
++                          (void *)arb_guard_hook, (void **)&orig_fn);
++              return 0;
++          }
++          KPM_INIT(arb_init); KPM_CONTROL(arb_ctrl); KPM_EXIT(arb_exit);
++          ARBC
++
++          # KPM header path: zip layout or flat fallback
++          HDR_INCLUDE=""
++          if [ -d "arb_kpm_build/headers" ]; then
++            HDR_INCLUDE="-Iarb_kpm_build/headers"
++          else
++            HDR_INCLUDE="-Iarb_kpm_build"
++          fi
++
++          "$CLANG" --target=aarch64-linux-android31 \
++            -fPIC -shared \
++            $HDR_INCLUDE \
++            -O2 -fno-stack-protector \
++            -o arb_kpm_build/arb_guard.kpm \
++            arb_kpm_build/arb_guard.c \
++            && echo "ARB Guard KPM built successfully" \
++            || echo "WARNING: ARB Guard KPM build failed — KPM headers may need manual download"
++
++          ls -lh arb_kpm_build/arb_guard.kpm 2>/dev/null || true
++
+       - name: 克隆 AnyKernel3 并打包
+         id: create_zip
+         run: |
+@@ -733,6 +805,15 @@ jobs:
+           if [[ ${{ github.event.inputs.kpm_enable }} == 'true' ]]; then
+             wget https://github.com/cctv18/KPatch-Next/releases/latest/download/kpn.zip
+           fi
++          if [[ "${{ github.event.inputs.arb_guard_enable }}" == "true" && "${{ github.event.inputs.kpm_enable }}" == "true" ]]; then
++            if [ -f "${{ github.workspace }}/arb_kpm_build/arb_guard.kpm" ]; then
++              mkdir -p kpm
++              cp "${{ github.workspace }}/arb_kpm_build/arb_guard.kpm" kpm/arb_guard.kpm
++              echo "ARB Guard KPM included in AnyKernel3 zip (kpm/arb_guard.kpm)"
++            else
++              echo "WARNING: arb_guard.kpm not found, skipping inclusion"
++            fi
++          fi
+           if [[ -n "${{ github.event.inputs.kernel_suffix }}" ]]; then
+             AK3_NAME=AnyKernel3_${KSU_TYPENAME}_${{ env.KSUVER }}_${{ env.KERNEL_VERSION }}_${{ github.event.inputs.kernel_suffix }}.zip
+           else

--- a/submodules/patcher/include/patchs/oplus/olock_recovery.h
+++ b/submodules/patcher/include/patchs/oplus/olock_recovery.h
@@ -1,0 +1,6 @@
+#ifndef OPLUS_OLOCK_RECOVERY_H
+#define OPLUS_OLOCK_RECOVERY_H
+#include <stdint.h>
+#include <stdbool.h>
+bool patch_olock_recovery(char* buffer, int32_t size);
+#endif /* OPLUS_OLOCK_RECOVERY_H */

--- a/submodules/patcher/src/patchs/core.c
+++ b/submodules/patcher/src/patchs/core.c
@@ -173,6 +173,7 @@ int32_t patch_adrl_unlocked_to_locked(char* buffer, int32_t size, uint64_t load_
 
 #include "patchs/oplus/warning.h"
 #include "patchs/oplus/forceenablefastboot.h"
+#include "patchs/oplus/olock_recovery.h"
 bool PatchBuffer(char* data, int32_t size) {
     if (patch_abl_gbl(data, size) != 0)
         printf("Warning: Failed to patch ABL GBL\n");
@@ -208,6 +209,9 @@ bool PatchBuffer(char* data, int32_t size) {
 
 
     //oplus
+    if (!patch_olock_recovery(data, size)) {
+        printf("OPlus Warning: patch_olock_recovery failed — recovery may be blocked on locked device\n");
+    }
     if (!patch_warning(data, size, global_var_offset)) {
         printf("OPlus Warning: patch_warning failed\n");
     }

--- a/submodules/patcher/src/patchs/oplus/olock_recovery.c
+++ b/submodules/patcher/src/patchs/oplus/olock_recovery.c
@@ -1,0 +1,93 @@
+#include "patchs/oplus/olock_recovery.h"
+#include "arm64_inst/utils.h"
+
+/*
+ * OPlus ABL contains a proprietary "olock" (secure lock state) check at the
+ * recovery boot path, completely separate from AVB lock state (offset 0x3C5).
+ * It reads a flag at struct offset 0xA6C and explicitly blocks recovery boot
+ * when the device reports as locked, leading to an infinite loop.
+ *
+ * The unique anchor for this block is the instruction sequence:
+ *   CMP  W8,  #1
+ *   CSET Wx,  EQ      ; <-- anchor - 8
+ *   CMP  W9,  #1
+ *   CCMP W8,  #1, #0, EQ  ; <-- anchor (bytes: 00 09 41 7A)
+ *   B.NE <allow_path>     ; <-- anchor + 4  (falls through to "Not allow Recovery")
+ *
+ * Two patches are applied:
+ *  1. CSET Wx, EQ  --> MOV Wx, WZR  (force register to 0 so CBZ always skips fastboot block)
+ *  2. B.NE target  --> B target      (unconditionally jump to the allowed recovery path)
+ */
+
+/* CCMP W8, #1, #0, EQ  =  00 09 41 7A (little-endian) */
+static const uint8_t CCMP_ANCHOR[4] = { 0x00, 0x09, 0x41, 0x7A };
+
+/* CMP W8, #1  =  1F 05 00 71 */
+static const uint8_t CMP_W8_1[4]    = { 0x1F, 0x05, 0x00, 0x71 };
+
+/* CMP W9, #1  =  3F 05 00 71 */
+static const uint8_t CMP_W9_1[4]    = { 0x3F, 0x05, 0x00, 0x71 };
+
+static bool bytes_match(const char* buf, int32_t off, const uint8_t* pattern, int n) {
+    for (int i = 0; i < n; i++)
+        if ((uint8_t)buf[off + i] != pattern[i]) return false;
+    return true;
+}
+
+bool patch_olock_recovery(char* buffer, int32_t size) {
+    if (size < 20) return false;
+
+    for (int32_t i = 0; i <= size - 20; i += 4) {
+        /* Locate CCMP W8,#1,#0,EQ anchor */
+        if (!bytes_match(buffer, i, CCMP_ANCHOR, 4)) continue;
+
+        /* Validate: CMP W8,#1  at i-12 */
+        if (i < 12) continue;
+        if (!bytes_match(buffer, i - 12, CMP_W8_1, 4)) continue;
+
+        /* Validate: CMP W9,#1  at i-4 */
+        if (!bytes_match(buffer, i - 4, CMP_W9_1, 4)) continue;
+
+        /* Validate: CSET Wx,EQ at i-8: encoding 0x1A9F17xx (xx encodes Rd in [4:0]) */
+        uint32_t cset_raw = (uint8_t)buffer[i-8]
+                          | ((uint8_t)buffer[i-7] << 8)
+                          | ((uint8_t)buffer[i-6] << 16)
+                          | ((uint8_t)buffer[i-5] << 24);
+        if ((cset_raw & 0xFFFFFFE0) != 0x1A9F17E0) {
+            /* 0x1A9F17E0 with Rd masked to 0; any Rd in low 5 bits is valid */
+            /* mask: top 27 bits must match 0x1A9F17E0>>5 = 0x0D4F8BF */
+            if ((cset_raw >> 5) != (0x1A9F17E0 >> 5)) continue;
+        }
+
+        /* Validate: B.NE at i+4: byte[3]=0x54, condition bits [3:0]=0x01 (NE) */
+        if (i + 8 > size) continue;
+        uint8_t bne_b3 = (uint8_t)buffer[i + 7];
+        uint8_t bne_b0 = (uint8_t)buffer[i + 4];
+        if (bne_b3 != 0x54) continue;
+        if ((bne_b0 & 0x0F) != 0x01) continue; /* condition NE = 0x1 */
+
+        printf("OLock recovery block found at anchor 0x%X\n", i);
+
+        /* Patch 1: CSET Wx,EQ  -->  MOV Wx,WZR  (ORR Wx,WZR,WZR = 0x2A1F03E0|Rd) */
+        uint8_t rd = (uint8_t)(cset_raw & 0x1F);
+        uint32_t mov_wzr = 0x2A1F03E0 | rd;
+        write_instr(buffer, i - 8, mov_wzr);
+        printf("  0x%X: CSET W%d,EQ --> MOV W%d,WZR\n", i - 8, rd, rd);
+
+        /* Patch 2: B.NE target  -->  B target (unconditional) */
+        uint32_t bne_raw = (uint8_t)buffer[i+4]
+                         | ((uint8_t)buffer[i+5] << 8)
+                         | ((uint8_t)buffer[i+6] << 16)
+                         | ((uint8_t)buffer[i+7] << 24);
+        /* B.NE: bits[23:5] = imm19; B: 0x14000000 | imm26; imm19 becomes imm26 */
+        int32_t imm19 = (int32_t)(bne_raw << 8) >> 13; /* sign-extend imm19 */
+        uint32_t b_uncond = 0x14000000 | ((uint32_t)(imm19) & 0x03FFFFFF);
+        write_instr(buffer, i + 4, b_uncond);
+        printf("  0x%X: B.NE --> B (unconditional allow recovery)\n", i + 4);
+
+        return true;
+    }
+
+    printf("OPlus olock recovery block not found\n");
+    return false;
+}

--- a/targets/magisk_module/module/customize.sh
+++ b/targets/magisk_module/module/customize.sh
@@ -92,6 +92,7 @@ set_perm_recursive "$MODPATH/bin" 0 0 0755 0755
 set_perm_recursive "$MODPATH/webroot" 0 0 0755 0644
 set_perm "$MODPATH/module.prop" 0 0 0644
 set_perm "$MODPATH/customize.sh" 0 0 0755
+set_perm "$MODPATH/post-fs-data.sh" 0 0 0755
 
 detect_current_slot() {
   case "$(getprop ro.boot.slot_suffix 2>/dev/null)" in

--- a/targets/magisk_module/module/post-fs-data.sh
+++ b/targets/magisk_module/module/post-fs-data.sh
@@ -1,0 +1,21 @@
+#!/system/bin/sh
+# ARB eFuse write suppression.
+#
+# ColorOS 16.0.8+ android.hardware.boot HAL writes "1" to this sysfs node
+# during boot, which causes qcom-dload-mode.ko to invoke
+# qcom_scm_update_rollback_version() → SMC 0x01/0x1E → TrustZone → QFPROM.
+# Removing write access before `class_start hal` prevents the blow.
+#
+# This script runs at post-fs-data, before any HAL service starts.
+# qcom-dload-mode.ko is loaded in first-stage init (vendor_boot ramdisk),
+# so the sysfs node already exists by the time we run.
+
+ARB_SYSFS="/sys/kernel/dload/update_arb"
+
+if [ -f "$ARB_SYSFS" ]; then
+    chmod 000 "$ARB_SYSFS" 2>/dev/null
+    echo "[arb_guard] blocked $ARB_SYSFS" > /dev/kmsg
+else
+    # Node absent — module not loaded or path changed. Log for debugging.
+    echo "[arb_guard] WARNING: $ARB_SYSFS not found" > /dev/kmsg
+fi


### PR DESCRIPTION
通过拒绝熔断boot早期sysfs熔断信号传递来答到抑制熔断的目的（理论上）
仅作为保底措施避免强制更新使用