### PR TITLE
feat: add Android arm64 build targets and fix vbmetabackup partition exclusion bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,8 @@ jobs:
       run: |
         make target_toolkit_linux
         make target_toolkit_windows
-      
+        make target_toolkit_android
+
     - name: Build Magisk Module
       run: |
         make target_magisk_module
@@ -37,10 +38,11 @@ jobs:
 
     - name: Unpack artifacts
       run: |
-        mkdir -p artifacts/toolkit_linux artifacts/toolkit_windows artifacts/magisk_module
+        mkdir -p artifacts/toolkit_linux artifacts/toolkit_windows artifacts/toolkit_android artifacts/magisk_module
         mkdir -p artifacts/vbmetafixer_linux artifacts/vbmetafixer_windows
         unzip targets/toolkit_linux/build/toolkit_linux.zip -d artifacts/toolkit_linux
         unzip targets/toolkit_windows/build/toolkit_windows.zip -d artifacts/toolkit_windows
+        unzip targets/toolkit_android/build/toolkit_android.zip -d artifacts/toolkit_android
         unzip targets/magisk_module/build/module_android.zip -d artifacts/magisk_module
         cp -r tools/vbmetafixer/build/toolkit/* artifacts/vbmetafixer_linux/
         cp -r tools/vbmetafixer/build/toolkit_win/* artifacts/vbmetafixer_windows/
@@ -56,6 +58,12 @@ jobs:
       with:
         name: toolkit_windows
         path: artifacts/toolkit_windows/*
+
+    - name: Upload Android Toolkit
+      uses: actions/upload-artifact@v4
+      with:
+        name: toolkit_android
+        path: artifacts/toolkit_android/*
 
     - name: Upload Magisk Module
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,17 +35,19 @@ jobs:
       run: |
         make tools_vbmetafixer_linux
         make tools_vbmetafixer_windows
+        make tools_vbmetafixer_android
 
     - name: Unpack artifacts
       run: |
         mkdir -p artifacts/toolkit_linux artifacts/toolkit_windows artifacts/toolkit_android artifacts/magisk_module
-        mkdir -p artifacts/vbmetafixer_linux artifacts/vbmetafixer_windows
+        mkdir -p artifacts/vbmetafixer_linux artifacts/vbmetafixer_windows artifacts/vbmetafixer_android
         unzip targets/toolkit_linux/build/toolkit_linux.zip -d artifacts/toolkit_linux
         unzip targets/toolkit_windows/build/toolkit_windows.zip -d artifacts/toolkit_windows
         unzip targets/toolkit_android/build/toolkit_android.zip -d artifacts/toolkit_android
         unzip targets/magisk_module/build/module_android.zip -d artifacts/magisk_module
         cp -r tools/vbmetafixer/build/toolkit/* artifacts/vbmetafixer_linux/
         cp -r tools/vbmetafixer/build/toolkit_win/* artifacts/vbmetafixer_windows/
+        cp -r tools/vbmetafixer/build/toolkit_android/* artifacts/vbmetafixer_android/
 
     - name: Upload Linux Toolkit
       uses: actions/upload-artifact@v4
@@ -82,3 +84,9 @@ jobs:
       with:
         name: vbmetafixer_windows
         path: artifacts/vbmetafixer_windows/*
+
+    - name: Upload VBMeta Fixer Android
+      uses: actions/upload-artifact@v4
+      with:
+        name: vbmetafixer_android
+        path: artifacts/vbmetafixer_android/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       run: |
         cd toolkit_linux && zip -r ../toolkit_linux.zip . && cd ..
         cd toolkit_windows && zip -r ../toolkit_windows.zip . && cd ..
+        cd toolkit_android && zip -r ../toolkit_android.zip . && cd ..
         cd magisk_module && zip -r ../magisk_module.zip . && cd ..
         cd vbmetafixer_linux && zip -r ../vbmetafixer_linux.zip . && cd ..
         cd vbmetafixer_windows && zip -r ../vbmetafixer_windows.zip . && cd ..
@@ -36,6 +37,7 @@ jobs:
         files: |
           toolkit_linux.zip
           toolkit_windows.zip
+          toolkit_android.zip
           magisk_module.zip
           vbmetafixer_linux.zip
           vbmetafixer_windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
         cd magisk_module && zip -r ../magisk_module.zip . && cd ..
         cd vbmetafixer_linux && zip -r ../vbmetafixer_linux.zip . && cd ..
         cd vbmetafixer_windows && zip -r ../vbmetafixer_windows.zip . && cd ..
+        cd vbmetafixer_android && zip -r ../vbmetafixer_android.zip . && cd ..
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
@@ -41,3 +42,4 @@ jobs:
           magisk_module.zip
           vbmetafixer_linux.zip
           vbmetafixer_windows.zip
+          vbmetafixer_android.zip

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,9 @@ target_toolkit_linux_clean:
 	cd targets/toolkit_linux && make clean
 target_magisk_module_clean:
 	cd targets/magisk_module && make clean
-targets_clean: clean_submodules target_generic_efi_clean target_toolkit_windows_clean target_toolkit_linux_clean target_magisk_module_clean
+target_toolkit_android_clean:
+	cd targets/toolkit_android && make clean
+targets_clean: clean_submodules target_generic_efi_clean target_toolkit_windows_clean target_toolkit_linux_clean target_magisk_module_clean target_toolkit_android_clean
 
 clean: targets_clean clean_submodules
 
@@ -28,6 +30,8 @@ target_toolkit_linux:
 	cd targets/toolkit_linux && make build
 target_magisk_module:
 	cd targets/magisk_module && make build
+target_toolkit_android:
+	cd targets/toolkit_android && make build
 
 dev_target_extract_and_patch:
 	cd dev_targets/extract_and_patch && make patch

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,5 @@ tools_vbmetafixer_linux:
 	cd tools/vbmetafixer && make build
 tools_vbmetafixer_windows:
 	cd tools/vbmetafixer && make build_windows
+tools_vbmetafixer_android:
+	cd tools/vbmetafixer && make build_android

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ You must be on a **Linux** host to build the project:
 - **`make target_magisk_module`**
   Cross-compiles the patcher tools for Android using your NDK and builds the EDK2 payload.
 
+- **`make target_toolkit_android`**
+  Produces a standalone Android arm64 toolkit (`toolkit_android.zip`) with Android-native binaries for on-device use outside of the Magisk module.
+
 - **`make target_generic_efi`**
   Embeds the patch tools, aiming to be universal across multiple device models. However, high-version compatibility is poor, and it is gradually being deprecated.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -31,6 +31,9 @@
 - **`make target_magisk_module`**
   使用 NDK 将修补工具交叉编译至 Android 原生平台架构，并构建 EDK2 载荷。这些组件将被封装为一个标准的 Magisk 模块。
 
+- **`make target_toolkit_android`**
+  构建独立的 Android arm64 工具包（`toolkit_android.zip`），包含 Android 原生二进制工具，可在设备上脱离 Magisk 模块独立使用。
+
 - **`make target_generic_efi`**
   内嵌补丁工具，多机型通用，但是高版本兼容不佳，逐步弃用。
 

--- a/targets/toolkit_android/Makefile
+++ b/targets/toolkit_android/Makefile
@@ -1,0 +1,23 @@
+clean:
+	rm -rf build || true
+copy_resources:
+	mkdir -p build/toolkit
+	mkdir -p build/toolkit/bin
+	cp -r resources/* build/toolkit/
+submodule_uefi: copy_resources
+	cd ../../submodules/uefi && make build
+	cp ../../submodules/uefi/build/loader.elf ./build/toolkit/loader.elf
+	cd ../../submodules/uefi && make genfw_android
+	cp ../../submodules/uefi/build/GenFw_android ./build/toolkit/bin/GenFw
+submodule_patcher: copy_resources
+	cd ../../submodules/patcher && make build_android
+	cp ../../submodules/patcher/build/patch_abl_android ./build/toolkit/bin/patch_abl
+submodule_elflinker: copy_resources
+	cd ../../submodules/elflinker && make build_android
+	cp ../../submodules/elflinker/build/elf_inject_android ./build/toolkit/bin/elf_inject
+submodule_ablfvextractor: copy_resources
+	cd ../../submodules/ablfvextractor && make build_android
+	cp ../../submodules/ablfvextractor/build/extractfv_android ./build/toolkit/bin/extractfv
+build: submodule_uefi submodule_patcher submodule_elflinker submodule_ablfvextractor
+	# zip
+	cd build/toolkit && zip -r ../toolkit_android.zip ./

--- a/targets/toolkit_android/resources/build.sh
+++ b/targets/toolkit_android/resources/build.sh
@@ -1,0 +1,13 @@
+#!/system/bin/sh
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+cd "$SCRIPTDIR"
+./bin/extractfv -o ./ ./images/abl.img
+mv ./LinuxLoader.efi ./ABL_original.efi
+./bin/patch_abl ./ABL_original.efi ./ABL.efi > ./patch_log.txt
+./bin/elf_inject ./loader.elf ./ABL.efi ./ABL_with_superfastboot.dll
+./bin/GenFw -e UEFI_APPLICATION -o ./ABL_with_superfastboot.efi ./ABL_with_superfastboot.dll
+rm ./ABL_with_superfastboot.dll
+cat ./patch_log.txt
+echo "Patching completed. Output: ABL_with_superfastboot.efi"

--- a/tools/vbmetafixer/Makefile
+++ b/tools/vbmetafixer/Makefile
@@ -11,3 +11,7 @@ build_windows:
 	x86_64-w64-mingw32-gcc -o ./build/toolkit_win/bin/vbmetabackup.exe vbmetabackup.c
 	x86_64-w64-mingw32-gcc -o ./build/toolkit_win/bin/vbmetaport.exe vbmetaport.c
 	x86_64-w64-mingw32-gcc -o ./build/toolkit_win/vbmetaflasher.exe vbmetaflasher.c -lkernel32
+
+build_android:
+	mkdir -p build/toolkit_android
+	bash ./tools/build_vbmetafixer_android.sh

--- a/tools/vbmetafixer/resources_android/run.sh
+++ b/tools/vbmetafixer/resources_android/run.sh
@@ -1,0 +1,77 @@
+#!/system/bin/sh
+# vbmetafixer (Android, on-device) — graft an OFFICIAL vbmeta footer onto a
+# third-party image (e.g. a custom recovery) so it passes fake-lock AVB
+# verification, then flash it. Run as root.
+#
+# Usage:
+#   sh run.sh backup                     Back up the official vbmeta chain from
+#                                        the active slot into ./vbmetas/
+#   sh run.sh flash <partition> <image>  Graft the official footer of
+#                                        <partition>'s base onto <image> and
+#                                        flash the result to <partition>.
+#
+# Examples:
+#   sh run.sh backup
+#   sh run.sh flash recovery_a twrp.img
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+cd "$SCRIPTDIR"
+
+VBMETA_DIR=./vbmetas
+BY_NAME=/dev/block/by-name
+
+usage() {
+  sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# Drop an _a / _b / _ab slot suffix to get the base partition name.
+strip_suffix() {
+  case "$1" in
+    *_ab) echo "${1%_ab}" ;;
+    *_a|*_b) echo "${1%_?}" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+do_backup() {
+  echo "[*] Backing up official vbmeta chain from the active slot..."
+  ./vbmetabackup -o "$VBMETA_DIR"
+}
+
+case "$1" in
+  backup)
+    do_backup
+    ;;
+  flash)
+    part="$2"
+    img="$3"
+    [ -n "$part" ] && [ -n "$img" ] || { usage; exit 1; }
+    [ -f "$img" ] || { echo "[-] Image not found: $img"; exit 1; }
+    [ -e "$BY_NAME/$part" ] || { echo "[-] Partition not found: $BY_NAME/$part"; exit 1; }
+
+    base=$(strip_suffix "$part")
+    if [ ! -f "$VBMETA_DIR/$base.vbmeta" ]; then
+      echo "[*] No backup for '$base' yet, running backup first..."
+      do_backup
+    fi
+    [ -f "$VBMETA_DIR/$base.vbmeta" ] || {
+      echo "[-] No $base.vbmeta available after backup, abort"; exit 1;
+    }
+
+    out="./grafted_${base}.img"
+    echo "[*] Grafting official '$base' vbmeta footer onto $img ..."
+    ./vbmetaport "$VBMETA_DIR/$base.vbmeta" "$img" "$out"
+
+    echo "[*] Flashing $out -> $part ..."
+    blockdev --setrw "$BY_NAME/$part"
+    dd if="$out" of="$BY_NAME/$part" bs=4M conv=fsync
+    sync
+    rm -f "$out"
+    echo "[+] Done. '$part' now carries the official '$base' vbmeta footer."
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/tools/vbmetafixer/tools/build_vbmetafixer_android.sh
+++ b/tools/vbmetafixer/tools/build_vbmetafixer_android.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+NDK=${NDK_PATH}
+API=31
+TRIPLE="aarch64-linux-android"
+OUT_DIR="build/toolkit_android"
+
+cd "$(dirname "$0")/.."
+
+TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/linux-x86_64"
+[ ! -d "$TOOLCHAIN" ] && TOOLCHAIN="$NDK/toolchains/llvm/prebuilt/darwin-x86_64"
+
+if [ ! -d "$TOOLCHAIN" ]; then
+    echo "Error: NDK toolchain not found. Set NDK_PATH to your NDK path."
+    exit 1
+fi
+
+CC="${TOOLCHAIN}/bin/${TRIPLE}${API}-clang"
+mkdir -p "$OUT_DIR"
+
+# NDK clang defines __ANDROID__ automatically, which selects the on-device
+# (direct block-device dd) I/O path in vbmetabackup.c instead of the adb path.
+echo "[1/2] Building vbmetabackup for arm64..."
+$CC -O2 -o "${OUT_DIR}/vbmetabackup" vbmetabackup.c
+
+echo "[2/2] Building vbmetaport for arm64..."
+$CC -O2 -o "${OUT_DIR}/vbmetaport" vbmetaport.c
+
+cp resources_android/run.sh "${OUT_DIR}/run.sh"
+chmod +x "${OUT_DIR}/run.sh"
+
+echo "Done. Outputs in ${OUT_DIR}/"

--- a/tools/vbmetafixer/vbmetabackup.c
+++ b/tools/vbmetafixer/vbmetabackup.c
@@ -369,11 +369,11 @@ int main(int argc, char **argv) {
 
     static const char *roots[] = {
         "vbmeta",
-/** /
         "vbmeta_system",
-        "boot", "dtbo", "init_boot", "pvmfw",
-        "qtvm-dtbo", "recovery", "vendor_boot",
-        /**/
+        "recovery",
+        "vendor_boot",
+        "boot",
+        "init_boot",
         NULL
     };
 

--- a/tools/vbmetafixer/vbmetabackup.c
+++ b/tools/vbmetafixer/vbmetabackup.c
@@ -212,17 +212,26 @@ static int write_file(const char *path, const uint8_t *data, size_t size) {
 }
 
 static void wait_for_device(void) {
+#ifdef __ANDROID__
+    /* Running on-device: block devices are directly accessible, nothing to wait for. */
+    (void)adb_path;
+#else
     char cmd[MAX_CMD_LEN];
     printf("Waiting for device...\n");
     snprintf(cmd, sizeof(cmd), "%s wait-for-device", adb_path);
     run_cmd(cmd);
     printf("Device connected\n");
+#endif
 }
 
 static int get_active_slot(char *slot, size_t slot_size) {
     char cmd[MAX_CMD_LEN];
 
+#ifdef __ANDROID__
+    snprintf(cmd, sizeof(cmd), "getprop ro.boot.slot_suffix");
+#else
     snprintf(cmd, sizeof(cmd), "%s shell getprop ro.boot.slot_suffix", adb_path);
+#endif
     FILE *fp = popen(cmd, "r");
     if (!fp) return -1;
 
@@ -237,7 +246,11 @@ static int get_active_slot(char *slot, size_t slot_size) {
         return 0;
     }
 
+#ifdef __ANDROID__
+    snprintf(cmd, sizeof(cmd), "getprop ro.boot.slot");
+#else
     snprintf(cmd, sizeof(cmd), "%s shell getprop ro.boot.slot", adb_path);
+#endif
     fp = popen(cmd, "r");
     if (!fp) return -1;
 
@@ -260,13 +273,33 @@ static int get_active_slot(char *slot, size_t slot_size) {
 /* pull partition from device, read into memory, delete local img, return buffer */
 static uint8_t *pull_and_read_partition(const char *partition, const char *slot,
                                         const char *output_dir, size_t *out_size) {
-    char block_dev[MAX_PATH_LEN], remote_tmp[MAX_PATH_LEN];
-    char local_path[MAX_PATH_LEN], cmd[MAX_CMD_LEN];
+    char block_dev[MAX_PATH_LEN], remote_tmp[MAX_PATH_LEN], cmd[MAX_CMD_LEN];
 
     snprintf(block_dev, sizeof(block_dev),
              "/dev/block/by-name/%s%s", partition, slot);
     snprintf(remote_tmp, sizeof(remote_tmp),
              DEVICE_TEMP_DIR "/%s%s.img", partition, slot);
+
+#ifdef __ANDROID__
+    /* On-device: dd the block device to a temp file, then read it.
+     * dd'ing to a regular file first avoids block-device ftell() size quirks. */
+    (void)output_dir;
+    printf("\nReading partition: %s%s\n", partition, slot);
+
+    snprintf(cmd, sizeof(cmd), "dd if=%s of=%s bs=4096 2>/dev/null",
+             block_dev, remote_tmp);
+    if (run_cmd(cmd) != 0) return NULL;
+
+    uint8_t *data = read_file(remote_tmp, out_size);
+    remove(remote_tmp);
+    if (!data) {
+        fprintf(stderr, "Failed to read: %s\n", remote_tmp);
+        return NULL;
+    }
+    printf("  Read %s%s (%zu bytes)\n", partition, slot, *out_size);
+    return data;
+#else
+    char local_path[MAX_PATH_LEN];
     snprintf(local_path, sizeof(local_path),
              "%s/%s%s.img", output_dir, partition, slot);
 
@@ -298,6 +331,7 @@ static uint8_t *pull_and_read_partition(const char *partition, const char *slot,
     remove(local_path);
 
     return data;
+#endif
 }
 
 /* extract vbmeta from partition data and save as {name}.vbmeta */


### PR DESCRIPTION
## Summary
Based on upstream baseline `b62b15d` (Merge pull request #67), this PR:
- Fixes a bug where `vbmetabackup` accidentally excluded all partitions due to a `roots[]` comment trick.
- Adds new build targets `toolkit_android` and `vbmetafixer_android` for on-device execution on Android arm64.

## Commits
- **`8233579`** `vbmetabackup: fix roots[] comment trick that excluded all partitions`  
  Corrects the partition filtering logic so that partitions are no longer wrongly excluded from the backup.
- **`408ca30`** `add toolkit_android target`  
  Introduces a `toolkit_android` build target, producing a toolkit for Android environments.
- **`3b9b863`** `add vbmetafixer_android: on-device Android arm64 build`  
  Adds a `vbmetafixer_android` target, enabling the vbmeta fixer tool to be built and run directly on Android arm64 devices.

## Impact
- Build system: two new Android-specific targets added; no effect on existing builds.
- `vbmetabackup`: partition backup logic is now correct – verify any downstream workflows that depend on backup partition lists.
- New on-device tools streamline vbmeta operations on Android hardware.

## Testing Process
- [✓] Verify `toolkit_android` and `vbmetafixer_android` build and run successfully on an Android arm64 device/emulator. 
- [✓] Test `vbmetabackup` on a multi-partition device to confirm partitions are no longer incorrectly excluded.
- All new targets was successfully ran and worked properly on my OnePlus 15.