### PR TITLE
修复模块更新时moudles.prop被覆盖成旧版的问题

### DIFF
--- a/targets/magisk_module/module/customize.sh
+++ b/targets/magisk_module/module/customize.sh
@@ -22,20 +22,6 @@ echo "$LANG" > "$MODPATH/lang.txt"
 ksud module config set user_lang "$LANG" 2>/dev/null
 sleep 1
 
-cat > "$MODPATH/module.prop" <<EOF
-id=fake_bl_efisp
-version=5.0
-versionCode=12
-author=zaomi
-EOF
-
-if [ "$LANG" = "zh" ]; then
-  echo "name=假回锁" >> "$MODPATH/module.prop"
-  echo "description=自动刷新bl相关分区到非活动槽位" >> "$MODPATH/module.prop"
-else
-  echo "name=Fake BL EFISP" >> "$MODPATH/module.prop"
-  echo "description=Automatically flash BL-related partitions to inactive slot" >> "$MODPATH/module.prop"
-fi
 
 if [ "$LANG" = "zh" ]; then
   T_VERIFY="- 正在验证设备型号"


### PR DESCRIPTION
moudles.prop应该是唯一的,不要因为语言的变化而去修改moudles.prop的值,没必要